### PR TITLE
Add requirements.txt file for developers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+googleapis-common-protos>=1.5.8
+grpcio>=1.19.0
+grpcio-tools>=1.19.0
+protobuf>=3.7.0


### PR DESCRIPTION
Alternative way of installing dependencies for people used to doing `pip install -r requirements.txt`