### PR TITLE
Bump Travis lnd version to v0.6-beta

### DIFF
--- a/.travis/travis_before_install.sh
+++ b/.travis/travis_before_install.sh
@@ -19,7 +19,7 @@ sudo cp ${TRAVIS_BUILD_DIR}/bitcoin-${CORE_VERSION}/bin/bitcoin-cli /usr/local/b
 # Install LND
 #############
 
-export LND_VERSION="v0.6-beta-rc4"
+export LND_VERSION="v0.6-beta"
 
 # Install LND
 wget https://github.com/lightningnetwork/lnd/releases/download/${LND_VERSION}/lnd-linux-amd64-${LND_VERSION}.tar.gz


### PR DESCRIPTION
LND v0.6-beta now includes the invoices RPC compiled in by default along with numerous other 
changes opening up more functionality such as hold invoices

Signed-off-by: willcl-ark <will8clark@gmail.com>